### PR TITLE
Show timestamp in isoformat.

### DIFF
--- a/weather.py
+++ b/weather.py
@@ -160,7 +160,7 @@ class SwissWeather(CoordinatorEntity[SwissWeatherDataCoordinator], WeatherEntity
             wind_bearing = None
 
         return Forecast(condition=meteo_forecast.condition,
-                datetime=meteo_forecast.timestamp,
+                datetime=meteo_forecast.timestamp.isoformat(),
                 native_precipitation=meteo_forecast.precipitation[0],
                 native_temperature=temperature,
                 native_templow=meteo_forecast.temperatureMin[0],


### PR DESCRIPTION
This seems to fix #1 for me and lets me use the forecast in a template sensor, e.g. for plotting with apexchart as described [here](https://community.home-assistant.io/t/integrate-hourly-forecast-in-apex-charts-after-update-to-service-get-forecast/707448).