### PR TITLE
Improve entity names in example card

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Add Swiss Weather integration to Home Assistant. You'll be asked for a few piece
 
 Data for weather alert needs to be pulled out of a card. Example mushroom template card which shows most severe weather alert and a badge for more:
 
-```
+```yaml
 type: custom:mushroom-template-card
 icon: mdi:alert
 primary: " {{states('sensor.most_severe_weather_warning_at_8000') }} - {{states('sensor.most_severe_weather_warning_level_at_8000')}}"
-secondary: "{{state_attr('sensor.most_severe_weather_alert_at_8000', 'text')}}"
+secondary: "{{state_attr('sensor.most_severe_weather_warning_at_8000', 'text')}}"
 icon_color: >
-  {{ state_attr('sensor.most_severe_weather_warning_level_at_8134','icon_color') }}
+  {{ state_attr('sensor.most_severe_weather_warning_level_at_8000','icon_color') }}
 badge_color: red
 badge_icon: |
   {% set number_of_warnings=states("sensor.weather_warnings_at_8000") |int %}
@@ -54,9 +54,9 @@ badge_icon: |
 multiline_secondary: true
 tap_action:
   action: more-info
-  entity: sensor.most_severe_weather_alert_at_8000
+  entity: sensor.most_severe_weather_warning_at_8000
 visibility:
   - condition: state
-    entity: sensor.most_severe_weather_alert_at_8000
+    entity: sensor.most_severe_weather_warning_at_8000
     state_not: unavailable 
 ```


### PR DESCRIPTION
Update the entity names to match what entities will typically be called and unify the PLZ used in the example.