### PR TITLE
Bump swiss-pollen from 1.0.3 to 1.1.0

### DIFF
--- a/custom_components/swissweather/manifest.json
+++ b/custom_components/swissweather/manifest.json
@@ -10,6 +10,6 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/izacus/hass-swissweather/issues",
-  "requirements": ["requests==2.32.4", "swiss-pollen==1.0.3"],
+  "requirements": ["requests==2.32.4", "swiss-pollen==1.1.0"],
   "version": "1.2.0"
 }


### PR DESCRIPTION
Version 1.1.0 is fully backward compatible to 1.0.3.

Do not use new APIs until hass-swiss-pollen has released the update to swiss-pollen 1.1.0.

Please merge quickly and release a new version of hass-swissweather as it blocks the new release of hass-swiss-pollen (see issue #24)..