### PR TITLE
Switch local forecast endpoint to plzDetail v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is an integration to download data from [MeteoSwiss](https://www.meteoschwe
 
 It currently supports:
   * Current weather state - temperature, precipitation, humidity, wind, etc. for a given autmated measurement station.
-  * Hourly and daily weather forecast based on a location encoded with post nurmber.
+  * Hourly and daily weather forecast based on a location encoded with post nurmber, including the 8-day MeteoSwiss forecast.
   * Weather warnings (e.g. floods, fires, earthquake dangers, etc.) for the set location.
   * Pollen measurement status across a set of automated stations.
 

--- a/custom_components/swissweather/meteo.py
+++ b/custom_components/swissweather/meteo.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 CURRENT_CONDITION_URL= 'https://data.geo.admin.ch/ch.meteoschweiz.messwerte-aktuell/VQHA80.csv'
 
-FORECAST_URL= "https://app-prod-ws.meteoswiss-app.ch/v1/plzDetail?plz={:<06d}"
+FORECAST_URL= "https://app-prod-ws.meteoswiss-app.ch/v2/plzDetail?plz={:<06d}"
 FORECAST_USER_AGENT = "android-31 ch.admin.meteoswiss-2160000"
 
 CONDITION_CLASSES = {


### PR DESCRIPTION
- Use the MeteoSwiss v2/plzDetail endpoint instead of v1.
- This extends the local forecast from 6 to 8 days.
- It also provides longer 1h and 3h graph series.
- The currently used forecast fields remain compatible, because the v2 response keeps the existing structure and extends it with additional data. 