### PR TITLE
Fix future weather warnings being filtered out

### DIFF
--- a/custom_components/swissweather/coordinator.py
+++ b/custom_components/swissweather/coordinator.py
@@ -63,8 +63,7 @@ class SwissWeatherDataCoordinator(DataUpdateCoordinator[tuple[CurrentWeather | N
         in_count = len(warnings)
         now = datetime.datetime.now(UTC)
         valid_warnings = [warning for warning in warnings
-                          if (warning.validFrom is None or warning.validFrom <= now) and
-                             (warning.validTo is None or warning.validTo >= now)]
+                          if (warning.validTo is None or warning.validTo >= now)]
         valid_warnings = sorted(valid_warnings, key=lambda warning: warning.warningLevel, reverse=True)
         _LOGGER.info("Weather warnings - in: %d filtered: %d", in_count, len(valid_warnings))
         return valid_warnings


### PR DESCRIPTION
## Problem

Weather warnings issued by MeteoSwiss in advance (where `validFrom` is in the future) were incorrectly excluded from the displayed list. This means users never see upcoming warnings until they have already started.

Fixes #27

## Solution

Removed the `validFrom <= now` filter condition from `_sort_filter_weather_alerts` in `coordinator.py`. Warnings are now only filtered by their expiry time (`validTo`), so upcoming warnings are shown as soon as MeteoSwiss issues them.