### PR TITLE
Use plant-specific pollen level thresholds based on official MeteoSwiss classification

### DIFF
--- a/custom_components/swissweather/pollen.py
+++ b/custom_components/swissweather/pollen.py
@@ -21,6 +21,34 @@ class PollenLevel(StrEnum):
     STRONG = "Strong"
     VERY_STRONG = "Very Strong"
 
+# Plant-specific load thresholds (low, medium, strong) based on official MeteoSwiss classification:
+# https://www.meteoswiss.admin.ch/dam/jcr:43b4f361-8bc1-4af7-a232-c126de0f2f80/Belastungsklassen-der-allergenen-Pollenarten_E.pdf
+_POLLEN_THRESHOLDS: dict[str, tuple[int, int, int]] = {
+    "birch":   (10,  70, 300),
+    "grasses": (20,  50, 150),
+    "alder":   (10,  70, 250),
+    "hazel":   (10,  70, 250),
+    "beech":   (50, 130, 400),
+    "ash":     (10, 100, 350),
+    "oak":     (50, 130, 400),
+}
+_DEFAULT_POLLEN_THRESHOLDS = (10, 70, 250)
+
+def get_pollen_level(value: float | None, plant_key: str) -> PollenLevel | None:
+    """Return the pollen load level for a given value and plant type."""
+    if value is None:
+        return None
+    if value <= 0:
+        return PollenLevel.NONE
+    low, medium, strong = _POLLEN_THRESHOLDS.get(plant_key, _DEFAULT_POLLEN_THRESHOLDS)
+    if value <= low:
+        return PollenLevel.LOW
+    if value <= medium:
+        return PollenLevel.MEDIUM
+    if value <= strong:
+        return PollenLevel.STRONG
+    return PollenLevel.VERY_STRONG
+
 @dataclass
 class CurrentPollen:
     stationAbbr: str

--- a/custom_components/swissweather/sensor.py
+++ b/custom_components/swissweather/sensor.py
@@ -47,7 +47,7 @@ from .const import (
     DOMAIN,
 )
 from .meteo import CurrentWeather, Warning, WarningLevel, WarningType
-from .pollen import CurrentPollen, PollenLevel
+from .pollen import CurrentPollen, PollenLevel, get_pollen_level
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -386,15 +386,12 @@ class SwissPollenSensor(CoordinatorEntity[SwissPollenDataCoordinator], SensorEnt
     def icon(self):
         return "mdi:flower-pollen"
 
-def get_color_for_pollen_level(level: int) -> str:
-    """Returns icon color for the corresponding warning level."""
-    if level is not None:
-        if level <= 10:
-            return "gray"
-        elif level <= 70:
-            return "amber"
-        elif level <= 250:
-            return "red"
+def get_color_for_pollen_level(level: PollenLevel | None) -> str:
+    """Returns icon color for the corresponding pollen level."""
+    if level in (PollenLevel.MEDIUM,):
+        return "amber"
+    if level in (PollenLevel.STRONG, PollenLevel.VERY_STRONG):
+        return "red"
     return "gray"
 
 class SwissPollenLevelSensor(CoordinatorEntity[SwissPollenDataCoordinator], SensorEntity):
@@ -418,18 +415,7 @@ class SwissPollenLevelSensor(CoordinatorEntity[SwissPollenDataCoordinator], Sens
             return None
         currentState = self.coordinator.data
         value = self._sensor_entry.data_function(currentState)
-        if value is not None:
-            if value == 0:
-                return PollenLevel.NONE
-            elif value <= 10:
-                return PollenLevel.LOW
-            elif value <= 70:
-                return PollenLevel.MEDIUM
-            elif value <= 250:
-                return PollenLevel.STRONG
-            else:
-                return PollenLevel.VERY_STRONG
-        return None
+        return get_pollen_level(value, self._sensor_entry.key)
 
     @property
     def extra_state_attributes(self) -> dict[str, any] | None:
@@ -438,8 +424,9 @@ class SwissPollenLevelSensor(CoordinatorEntity[SwissPollenDataCoordinator], Sens
             return None
         currentState = self.coordinator.data
         value = self._sensor_entry.data_function(currentState)
+        level = get_pollen_level(value, self._sensor_entry.key)
         return {
-            'icon_color': get_color_for_pollen_level(value)
+            'icon_color': get_color_for_pollen_level(level)
         }
 
     @cached_property


### PR DESCRIPTION
## Summary

Closes #44

Previously, `SwissPollenLevelSensor` used the same fixed thresholds for all pollen types to calculate None/Low/Medium/Strong/Very Strong:

```python
if value <= 10:   → LOW
elif value <= 70:  → MEDIUM
elif value <= 250: → STRONG
else:              → VERY STRONG   # bug: also colored gray instead of red
```

This is replaced with per-plant thresholds from the **official MeteoSwiss load classification document** (same source used by [swiss-pollen](https://github.com/frimtec/swiss-pollen)):

| Plant   | LOW (≤) | MEDIUM (≤) | STRONG (≤) | VERY STRONG |
|---------|---------|------------|------------|-------------|
| Birch   | 10      | 70         | 300        | > 300       |
| Grasses | 20      | 50         | 150        | > 150       |
| Alder   | 10      | 70         | 250        | > 250       |
| Hazel   | 10      | 70         | 250        | > 250       |
| Beech   | 50      | 130        | 400        | > 400       |
| Ash     | 10      | 100        | 350        | > 350       |
| Oak     | 50      | 130        | 400        | > 400       |

## Changes

- **`pollen.py`**: Added `_POLLEN_THRESHOLDS` dict and `get_pollen_level(value, plant_key)` helper function
- **`sensor.py`**: `SwissPollenLevelSensor` now uses `get_pollen_level()` with the sensor's plant key; `get_color_for_pollen_level()` now takes a `PollenLevel` instead of a raw int value

## Bug fix included

Values above the STRONG threshold were incorrectly colored gray (due to fallthrough in the old `if/elif` chain). They are now correctly colored red.